### PR TITLE
feature: add messageTimestamp to MessageMetaData and implement a Comp…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 15
     default-labels:
       - "Type: dependencies"

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -33,11 +33,11 @@ jobs:
 
       # Build
       - name: Build with Maven
-        run: ./mvnw clean verify -U -B -T4
+        run: ./mvnw clean verify -U -B -T4 -ntp
 
       # itest
       - name: Run itest
-        run: ./mvnw integration-test failsafe:verify -Pitest -U -B -T4
+        run: ./mvnw integration-test failsafe:verify -Pitest -U -B -T4 -ntp
 
       - name: Upload coverage to Codecov
         if: github.event_name == 'push' && github.actor != 'dependabot[bot]'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -37,11 +37,11 @@ jobs:
 
       # Build
       - name: Build with Maven
-        run: ./mvnw clean verify -U -B -T4
+        run: ./mvnw clean verify -U -B -T4 -ntp
 
       # Publish release
       - name: Deploy a new release version to Maven Central
-        run: ./mvnw clean deploy -B -DskipTests -DskipExamples -Prelease -Dgpg.keyname="${{ secrets.GPG_KEYNAME }}" -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
+        run: ./mvnw clean deploy -B -ntp -DskipTests -DskipExamples -Prelease -Dgpg.keyname="${{ secrets.GPG_KEYNAME }}" -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
         env:
           OSS_CENTRAL_USERNAME: "${{ secrets.SONATYPE_USERNAME }}"
           OSS_CENTRAL_PASSWORD: "${{ secrets.SONATYPE_PASSWORD }}"

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -5,14 +5,14 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.4/apache-maven-3.8.4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.2/apache-maven-3.9.2-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar

--- a/bom/parent/pom.xml
+++ b/bom/parent/pom.xml
@@ -14,7 +14,7 @@
   <name>POM / Parent</name>
 
   <properties>
-    <spring-boot.version>2.7.5</spring-boot.version>
+    <spring-boot.version>2.7.12</spring-boot.version>
     <camunda-7.version>7.18.0</camunda-7.version>
     <camunda-bpm-data.version>1.2.8</camunda-bpm-data.version>
     <shedlock.version>4.38.0</shedlock.version>
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>org.mockito.kotlin</groupId>
       <artifactId>mockito-kotlin</artifactId>
-      <version>4.0.0</version>
+      <version>5.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/correlate/correlation/impl/MessageTimestampCorrelationMessageComparator.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/correlate/correlation/impl/MessageTimestampCorrelationMessageComparator.kt
@@ -1,0 +1,11 @@
+package io.holunda.camunda.bpm.correlate.correlation.impl
+
+import io.holunda.camunda.bpm.correlate.correlation.CorrelationMessage
+
+/**
+ * Correlation message comparator taking message timestamp as a reference.
+ */
+class MessageTimestampCorrelationMessageComparator : Comparator<CorrelationMessage> {
+  override fun compare(left: CorrelationMessage, right: CorrelationMessage): Int =
+    left.messageMetaData.messageTimestamp.compareTo(right.messageMetaData.messageTimestamp)
+}

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/correlate/correlation/metadata/MessageMetaData.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/correlate/correlation/metadata/MessageMetaData.kt
@@ -36,7 +36,7 @@ data class MessageMetaData(
    */
   constructor(snippet: MessageMetaDataSnippet) : this(
     messageId = requireNotNull(snippet.messageId) { "Message id must not be null" },
-    messageTimestamp = snippet.messageTimestamp ?: Instant.now(),
+    messageTimestamp = requireNotNull(snippet.messageTimestamp) { "Message timestamp must not be null" },
     payloadTypeInfo = requireNotNull(snippet.payloadTypeInfo) { "Payload type info must not be null" },
     payloadEncoding = requireNotNull(snippet.payloadEncoding) { "Payload encoding must be set" },
     timeToLive = snippet.timeToLive,

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/correlate/correlation/metadata/MessageMetaData.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/correlate/correlation/metadata/MessageMetaData.kt
@@ -11,6 +11,10 @@ data class MessageMetaData(
    */
   val messageId: String,
   /**
+   * Timestamp of the message.
+   */
+  val messageTimestamp: Instant,
+  /**
    * Payload type info.
    */
   val payloadTypeInfo: TypeInfo,
@@ -32,6 +36,7 @@ data class MessageMetaData(
    */
   constructor(snippet: MessageMetaDataSnippet) : this(
     messageId = requireNotNull(snippet.messageId) { "Message id must not be null" },
+    messageTimestamp = snippet.messageTimestamp ?: Instant.now(),
     payloadTypeInfo = requireNotNull(snippet.payloadTypeInfo) { "Payload type info must not be null" },
     payloadEncoding = requireNotNull(snippet.payloadEncoding) { "Payload encoding must be set" },
     timeToLive = snippet.timeToLive,

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/correlate/correlation/metadata/MessageMetaDataSnippet.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/correlate/correlation/metadata/MessageMetaDataSnippet.kt
@@ -37,44 +37,14 @@ data class MessageMetaDataSnippet(
     /**
      * Reducer for snippets.
      */
-    fun reduce(acc: MessageMetaDataSnippet, other: MessageMetaDataSnippet): MessageMetaDataSnippet =
-      acc.let {
-        if (other.messageId != null) {
-          it.copy(messageId = other.messageId)
-        } else {
-          it
-        }
-      }.let {
-        if (other.timeToLive != null) {
-          it.copy(timeToLive = other.timeToLive)
-        } else {
-          it
-        }
-      }.let {
-        if (other.expiration != null) {
-          it.copy(expiration = other.expiration)
-        } else {
-          it
-        }
-      }.let {
-        if (other.payloadEncoding != null) {
-          it.copy(payloadEncoding = other.payloadEncoding)
-        } else {
-          it
-        }
-      }.let {
-        if (other.payloadTypeInfo != TypeInfo.UNKNOWN && it.payloadTypeInfo.overwritePossible) {
-          it.copy(payloadTypeInfo = other.payloadTypeInfo)
-        } else {
-          it
-        }
-      }.let {
-        if (other.messageTimestamp != null) {
-          it.copy(messageTimestamp = other.messageTimestamp)
-        } else {
-          it
-        }
-      }
+    fun reduce(acc: MessageMetaDataSnippet, other: MessageMetaDataSnippet): MessageMetaDataSnippet = MessageMetaDataSnippet(
+        messageId = other.messageId ?: acc.messageId,
+        timeToLive = other.timeToLive ?: acc.timeToLive,
+        expiration = other.expiration ?: acc.expiration,
+        payloadEncoding = other.payloadEncoding ?: acc.payloadEncoding,
+        payloadTypeInfo = if(other.payloadTypeInfo != TypeInfo.UNKNOWN && acc.payloadTypeInfo.overwritePossible) other.payloadTypeInfo else acc.payloadTypeInfo,
+        messageTimestamp = other.messageTimestamp ?: acc.messageTimestamp
+      )
   }
 
   /**

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/correlate/persist/impl/DefaultMessagePersistenceService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/correlate/persist/impl/DefaultMessagePersistenceService.kt
@@ -54,6 +54,7 @@ class DefaultMessagePersistenceService(
         )
         val messageMetaData = MessageMetaData(
           messageId = entity.id,
+          messageTimestamp = entity.inserted,
           payloadTypeInfo = typeInfo,
           timeToLive = entity.timeToLiveDuration,
           payloadEncoding = entity.payloadEncoding,
@@ -163,7 +164,7 @@ class DefaultMessagePersistenceService(
     messageRepository.insert(
       MessageEntity(
         id = metaData.messageId,
-        inserted = clock.instant(),
+        inserted = metaData.messageTimestamp,
         payloadEncoding = metaData.payloadEncoding,
         payloadTypeNamespace = metaData.payloadTypeInfo.namespace,
         payloadTypeName = metaData.payloadTypeInfo.name,

--- a/extension/core/src/test/kotlin/io/holunda/camunda/bpm/correlate/TestFixtures.kt
+++ b/extension/core/src/test/kotlin/io/holunda/camunda/bpm/correlate/TestFixtures.kt
@@ -17,6 +17,7 @@ fun emptyMessage() = ObjectMessage(mapOf(), "")
 
 fun emptyMessageMetadata() = MessageMetaData(
   messageId = messageId(),
+  messageTimestamp = Instant.now(),
   payloadTypeInfo = TypeInfo.UNKNOWN,
   payloadEncoding = "",
   timeToLive = null,

--- a/extension/core/src/test/kotlin/io/holunda/camunda/bpm/correlate/ingress/message/DelegatingChannelMessageTest.kt
+++ b/extension/core/src/test/kotlin/io/holunda/camunda/bpm/correlate/ingress/message/DelegatingChannelMessageTest.kt
@@ -10,6 +10,7 @@ import io.holunda.camunda.bpm.correlate.ingress.impl.PersistingChannelMessageAcc
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.*
+import java.time.Instant
 
 /**
  * Test to simulate the usage of delegation message for Axon Framework use case.
@@ -27,7 +28,8 @@ internal class DelegatingChannelMessageTest {
       headers = mapOf(
         HeaderNames.ID to "VALUE",
         HeaderNames.PAYLOAD_TYPE_CLASS_NAME to PayloadType::class.java.canonicalName,
-        HeaderNames.PAYLOAD_ENCODING to "jackson"
+        HeaderNames.PAYLOAD_ENCODING to "jackson",
+        HeaderNames.TIMESTAMP to Instant.now().toString()
       ), payload = payload
     ),
     payloadSupplier = { payload -> convert(payload.deserializePayload()) }

--- a/extension/spring-cloud-stream/src/main/kotlin/io/holunda/camunda/bpm/correlate/ingress/cloudstream/KafkaStreamChannelMessageHeaderConverter.kt
+++ b/extension/spring-cloud-stream/src/main/kotlin/io/holunda/camunda/bpm/correlate/ingress/cloudstream/KafkaStreamChannelMessageHeaderConverter.kt
@@ -18,7 +18,14 @@ class KafkaStreamChannelMessageHeaderConverter : StreamChannelMessageHeaderConve
    */
   override fun extractMessageHeaders(message: Message<ByteArray>): Map<String, Any> {
     return builder()
-      .set(HEADER_MESSAGE_TIMESTAMP, Instant.ofEpochMilli(message.headers.timestamp!!).toString())
+      .set(
+        HEADER_MESSAGE_TIMESTAMP,
+        if (message.headers.timestamp != null) {
+          Instant.ofEpochMilli(message.headers.timestamp!!)
+        } else {
+          Instant.now()
+        }.toString()
+      )
       .set(HEADER_MESSAGE_ID, message.headers.id!!.toString())
       .build().apply {
         this.putAll(message.headers.normalized())

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>11</java.version>
-    <kotlin.version>1.7.21</kotlin.version>
+    <kotlin.version>1.8.22</kotlin.version>
   </properties>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -528,7 +528,7 @@
                     <version>11</version>
                   </requireJavaVersion>
                   <requireMavenVersion>
-                    <version>3.6.0</version>
+                    <version>3.9.0</version>
                   </requireMavenVersion>
                 </rules>
               </configuration>


### PR DESCRIPTION
…arator that sorts by it.

Fixes #44

Note: the approach of mapping `messageTimestamp` to `inserted` is subject to discussion. It keeps things simple because it doesn't require an extra field in `MessageEntity`, but one could argue that it is not completely clean because the `messageTimestamp` is not necessarily the time the message was inserted into the database. @zambrovski I would like to know your opinion regarding this choice.